### PR TITLE
Support for file encodings.

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -28,8 +28,9 @@ export default class {
       return
 
     this.createTime = fields.createTime
-
-    this.data = fields.data !== undefined ? fields.data : readFileSync(this.path).toString()
+    
+    this.encoding = fields.encoding
+    this.data = fields.data != undefined ? fields.data : readFileSync(this.path).toString(fields.encoding)
     this.sourceData = this.data
 
     if (fields.sourceMap)


### PR DESCRIPTION
Previously, Sigh would corrupt .png, .ogg, .gif files and the like when copying them. Adding an option for file encoding solves this.
